### PR TITLE
Add support for private class methods

### DIFF
--- a/lib/tout.rb
+++ b/lib/tout.rb
@@ -4,16 +4,19 @@ module Tout
   def publicize(klass, method)
     method_already_public = klass.method_defined?(method)
     private_method_defined = klass.private_method_defined?(method)
+    private_class_method_defined = klass.private_methods.include?(method) && !private_method_defined
 
     before(:each) do
       raise "Cannot publicize #{klass.name}##{method} as it is already public." if method_already_public
-      raise "Cannot publicize #{klass.name}##{method} no private method by that name exists." unless private_method_defined
+      raise "Cannot publicize #{klass.name}##{method} no private method by that name exists." unless private_method_defined || private_class_method_defined
 
       klass.send(:public, method) if private_method_defined && !method_already_public
+      klass.singleton_class.class_eval { public method } if private_class_method_defined && !method_already_public
     end
 
     after(:each) do
       klass.send(:private, method) if private_method_defined && !method_already_public
+      klass.singleton_class.class_eval { private method } if private_class_method_defined && !method_already_public
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,6 @@ RSpec.configure do |config|
   config.extend(Tout)
 
   config.before(:suite) do
-    puts "\nPlease note: This test suite is supposed to have one passing spec and two failing specs."
+    puts "\nPlease note: This test suite is supposed to have two passing specs and three failing specs."
   end
 end

--- a/spec/tout_spec.rb
+++ b/spec/tout_spec.rb
@@ -10,6 +10,14 @@ class NormalClass
   def private_foo
     "private"
   end
+
+  class << self
+    private
+
+    def private_class_foo
+      "private class"
+    end
+  end
 end
 
 RSpec.describe Tout do
@@ -24,6 +32,14 @@ RSpec.describe Tout do
 
       it "makes the method public" do
         expect(NormalClass.new.private_foo).to eq("private")
+      end
+    end
+
+    context "for a private class method" do
+      publicize(NormalClass, :private_class_foo)
+
+      it "makes the class method public" do
+        expect(NormalClass.private_class_foo).to eq("private class")
       end
     end
 

--- a/spec/tout_spec.rb
+++ b/spec/tout_spec.rb
@@ -12,6 +12,10 @@ class NormalClass
   end
 
   class << self
+    def public_class_foo
+      "public class"
+    end
+
     private
 
     def private_class_foo
@@ -25,6 +29,7 @@ RSpec.describe Tout do
 
     after(:all) do
       raise "Method privacy was not restored" if NormalClass.method_defined?(:private_foo)
+      raise "Class method privacy was not restored" if NormalClass.method_defined?(:private_class_foo)
     end
 
     context "for a private method" do
@@ -35,6 +40,14 @@ RSpec.describe Tout do
       end
     end
 
+    context "raises an error when given a public method" do
+      publicize(NormalClass, :public_foo)
+
+      it "raises an error" do
+        flunk
+      end
+    end
+
     context "for a private class method" do
       publicize(NormalClass, :private_class_foo)
 
@@ -42,9 +55,9 @@ RSpec.describe Tout do
         expect(NormalClass.private_class_foo).to eq("private class")
       end
     end
-
-    context "raises an error when given a public method" do
-      publicize(NormalClass, :public_foo)
+    
+    context "raises an error when given a public class method" do
+      publicize(NormalClass, :public_class_foo)
 
       it "raises an error" do
         flunk


### PR DESCRIPTION
Currently there's no support for publicizing private class methods. This PR adds such functionality by re-evaluating the class with `method` redefined as public:
```ruby
klass.singleton_class.class_eval { public method }
```